### PR TITLE
Fix #85

### DIFF
--- a/webdir-api/src/main/java/com/kttdevelopment/webdir/api/WebDirPlugin.java
+++ b/webdir-api/src/main/java/com/kttdevelopment/webdir/api/WebDirPlugin.java
@@ -73,19 +73,21 @@ public class WebDirPlugin {
      * @since 1.0.0
      * @author Ktt Development
      */
-    public final Map<String,? super Object> getPluginYml(){
+    @SuppressWarnings("rawtypes")
+    public final Map getPluginYml(){
         return new HashMap<>(service.getPluginYml());
     }
 
     /**
-     * Returns the config.yml from webdir as a map.
+     * Returns the config.yml from WebDir as a map.
      *
      * @return config.yml
      *
      * @since 1.0.0
      * @author Ktt Development
      */
-    public final Map<String,? super Object> getConfigYml(){
+    @SuppressWarnings("rawtypes")
+    public final Map getConfigYml(){
         return new HashMap<>(service.getConfigYml());
     }
 

--- a/webdir-client/src/main/java/com/kttdevelopment/webdir/client/renderer/DefaultFrontMatterLoader.java
+++ b/webdir-client/src/main/java/com/kttdevelopment/webdir/client/renderer/DefaultFrontMatterLoader.java
@@ -110,6 +110,7 @@ public class DefaultFrontMatterLoader {
         // sort so lower indexes are at the top (see next)
         configs.sort(Comparator.comparingInt(map -> {
             try{
+                //noinspection rawtypes
                 return Integer.parseInt(((Map) map.get(DEFAULT)).get(INDEX).toString());
             }catch(final ClassCastException | NullPointerException ignored){ // field not required, def -1
             }catch(final NumberFormatException e){

--- a/webdir-client/src/main/java/com/kttdevelopment/webdir/client/renderer/PageRenderer.java
+++ b/webdir-client/src/main/java/com/kttdevelopment/webdir/client/renderer/PageRenderer.java
@@ -6,8 +6,7 @@ import com.kttdevelopment.webdir.api.FileRender;
 import com.kttdevelopment.webdir.api.Renderer;
 import com.kttdevelopment.webdir.client.*;
 import com.kttdevelopment.webdir.client.plugin.PluginRendererEntry;
-import com.kttdevelopment.webdir.client.utility.ExceptionUtility;
-import com.kttdevelopment.webdir.client.utility.ToStringBuilder;
+import com.kttdevelopment.webdir.client.utility.*;
 
 import java.io.File;
 import java.io.IOException;
@@ -64,7 +63,8 @@ public class PageRenderer {
         {
              final Map<String,? super Object> defaultFrontMatter = defaultFrontMatterLoader.getDefaultFrontMatter(IN);
              if(defaultFrontMatter != null)
-                merged.putAll(defaultFrontMatter);
+                 //noinspection unchecked
+                 merged.putAll(MapUtility.deepCopy(defaultFrontMatter));
         }
         if(!online && bytes != null){ // online & null bytes will not have front matter
             final YamlFrontMatter frontMatter = new YamlFrontMatter(new String(bytes, StandardCharsets.UTF_8));

--- a/webdir-client/src/main/java/com/kttdevelopment/webdir/client/utility/MapUtility.java
+++ b/webdir-client/src/main/java/com/kttdevelopment/webdir/client/utility/MapUtility.java
@@ -1,0 +1,21 @@
+package com.kttdevelopment.webdir.client.utility;
+
+import java.util.*;
+
+public abstract class MapUtility {
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public static Map deepCopy(final Map map){
+        final Map copy = new HashMap();
+        map.forEach((k, v) -> {
+            if(v instanceof List)
+                copy.put(k, new ArrayList((List) v));
+            else if(v instanceof Map)
+                copy.put(k, deepCopy((Map) v));
+            else
+                copy.put(k, v);
+        });
+        return copy;
+    }
+
+}

--- a/webdir-client/src/test/java/com/kttdevelopment/webdir/client/utility/MapUtilityTests.java
+++ b/webdir-client/src/test/java/com/kttdevelopment/webdir/client/utility/MapUtilityTests.java
@@ -1,0 +1,30 @@
+package com.kttdevelopment.webdir.client.utility;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+public class MapUtilityTests {
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    @Test
+    public final void testDeepCopy(){
+        final List list = new ArrayList(){{
+            add("test");
+        }};
+        final Map map = Map.of(
+            "k", "v",
+            "l", list,
+            "m", Map.of(
+                "k", "v",
+                "l", list
+            )
+        );
+
+        ((List) MapUtility.deepCopy(map).get("l")).set(0, "null");
+
+        Assertions.assertEquals("test", list.get(0));
+    }
+
+}


### PR DESCRIPTION
- Changed renderer so a deep copy of defaults is used
- Made API more generic

### Prerequisites
*If **all** checks are not passed then the pull request will be closed.*

- [x] My code follows the style listed in [CONTRIBUTING](https://github.com/Ktt-Development/.github/blob/main/CONTRIBUTING.md).
- [x] I have checked that no other similar pull requests already exists.
- [x] Build compiles.
- [x] Build runs without exceptions.
- [x] I have added/modified documentation (if applicable).
- [x] I have added/modified test cases (if applicable).

### Changes Made
*List changes made and/or relevant issues.*

- Fixed issue where default configuration could be modified.
- Made API generic
